### PR TITLE
Fix for VLAN interfaces

### DIFF
--- a/generate-mc.sh
+++ b/generate-mc.sh
@@ -63,12 +63,11 @@ spec:
           [Unit]
           Description=out-of-tree driver loader
           # Start after the network is up
-          Wants=network-online.target
-          After=network-online.target
+          After=NetworkManager-wait-online.service openvswitch.service network.service nodeip-configuration.service
           # Also after docker.service (no effect on systems without docker)
           After=docker.service
           # Before kubelet.service (no effect on systems without kubernetes)
-          Before=kubelet.service
+          Before=kubelet.service ovs-configuration.service
 
           [Service]
           Type=oneshot

--- a/ptp-config.sh
+++ b/ptp-config.sh
@@ -43,3 +43,9 @@ fi
 if [ ! -z "${NIC_WITHOUT_GNSS}" ]; then
     echo 1 1 > /sys/class/net/${NIC_WITHOUT_GNSS}/device/ptp/ptp*/pins/${RX_PORT}
 fi
+
+# Give some time after the driver has initialized all cards before reloading NetworkManager
+sleep 60
+nmcli connection reload
+sleep 20
+nmcli networking on

--- a/ptp-config.sh
+++ b/ptp-config.sh
@@ -44,8 +44,26 @@ if [ ! -z "${NIC_WITHOUT_GNSS}" ]; then
     echo 1 1 > /sys/class/net/${NIC_WITHOUT_GNSS}/device/ptp/ptp*/pins/${RX_PORT}
 fi
 
-# Give some time after the driver has initialized all cards before reloading NetworkManager
-sleep 60
-nmcli connection reload
-sleep 20
-nmcli networking on
+# If you have a VLAN interface created via NMState or nmcli, and that interface
+# is OVN's main interface, the configure-ovs.sh script may not find the main IP
+# unless we manually start the interface after loading the out-of-tree driver
+# Set the ICE_VLAN_INTERFACES environment variable with the VLAN interfaces you
+# have defined (separated by blanks), so the script can ensure all of them are
+# enabled
+
+# Example values
+# ICE_VLAN_INTERFACES=""
+# ICE_VLAN_INTERFACES="ens1f1.100"
+# ICE_VLAN_INTERFACES="ens1f1.100 ens1f1.200"
+
+ICE_VLAN_INTERFACES=""
+
+if [ ! -z "${ICE_VLAN_INTERFACES}" ]; then
+    # Give some time after the driver has initialized all cards before reloading NetworkManager
+    sleep 60
+    nmcli connection reload
+    for INTERFACE in ${ICE_VLAN_INTERFACES}; do
+        echo "Re-enabling VLAN interface $INTERFACE"
+        nmcli conn up $INTERFACE
+    done
+fi


### PR DESCRIPTION
When a VLAN interface like ens2f3.100 is created on a NIC managed by the ice driver, the process to unload the in-tree driver and load the out-of-tree driver can cause some issues and leave the VLAN interface without connectivity. This is an issue if the VLAN interface is used as the main OVN interface, since it can leave the node without connectivity.

This PR fixes that by giving the user a chance to specify those interfaces, so they are re-enabled after loading the driver.